### PR TITLE
feat(argocd): brancher le repo privé staging-gitops

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,8 +154,8 @@ EOF
 | --------------------------------------------------------------------------- | ------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `infra/eso.yaml`                                                            | `eso`               | Installe External Secrets Operator                                                                                                                               |
 | `infra/post-install-cr.yaml` → [post-install-cr/](post-install-cr/)         | `post-install-cr`   | Crée le `ClusterSecretStore` GCPSM + middleware Traefik                                                                                                          |
-| `infra/argo-secret.yaml` → [argo-secrets/](argo-secrets/)                   | `argo-secrets`      | `ExternalSecret` qui peuplent `infra-secrets` et la clé SSH du repo privé                                                                                        |
-| `infra/external-repos.yaml` → [external-repos/](external-repos/)            | `external-repos`    | Branche le repo `private-gitops` (clé SSH)                                                                                                                       |
+| `infra/argo-secret.yaml` → [argo-secrets/](argo-secrets/)                   | `argo-secrets`      | `ExternalSecret` qui peuplent `infra-secrets` et les clés SSH des repos privés                                                                                   |
+| `infra/external-repos.yaml` → [external-repos/](external-repos/)            | `external-repos`    | Branche les repos privés `private-gitops` et `staging-gitops` (clés SSH)                                                                                         |
 | `infra/longhorn.yaml`                                                       | `longhorn`          | Storage                                                                                                                                                          |
 | `infra/metrics-server.yaml`                                                 | `metrics-server`    | Métriques instantanées (`kubectl top`, HPA). `--kubelet-insecure-tls` requis sur Talos                                                                           |
 | `infra/monitoring.yaml` → [monitoring/](monitoring/)                        | `monitoring`        | Métriques historisées : kube-prometheus-stack bridé + Grafana. Cf. [ADR 0001](docs/adr/0001-metriques-historisees-sous-contrainte-disque.md)                     |
@@ -169,17 +169,47 @@ EOF
 
 Les secrets suivants doivent exister dans GCP Secret Manager (projet `amonnier`) :
 
-| Clé GCPSM                           | Utilisation                                                                                                                                                                                            |
-| ----------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Clé GCPSM                           | Utilisation                                                                                                                                                                                             |
+| ----------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `k8s1-infra`                        | Bag de secrets pour l'infra : `email`, `entrypoint-ip`, `traefik-node-name`, … référencés via `<path:argocd:infra-secrets#...>` dans [infra-with-secrets/traefik.yaml](infra-with-secrets/traefik.yaml) |
-| `k8s1-github-private-gitops-deploy` | Deploy key SSH (clé privée) du repo `monnierant/private-gitops`                                                                                                                                        |
-| `k8s1-grafana`                      | JSON `{"admin-user": "...", "admin-password": "..."}` — consommé via `admin.existingSecret` par [monitoring/kube-prometheus-stack.yaml](monitoring/kube-prometheus-stack.yaml), sans passer par AVP    |
+| `k8s1-github-private-gitops-deploy` | Deploy key SSH (clé privée) du repo `monnierant/private-gitops`                                                                                                                                         |
+| `k8s1-github-staging-gitops-deploy` | Deploy key SSH (clé privée) du repo `MonniHermes/staging-gitops`, **en écriture** : l'Image Updater y pousse ses write-back Kustomize                                                                   |
+| `k8s1-grafana`                      | JSON `{"admin-user": "...", "admin-password": "..."}` — consommé via `admin.existingSecret` par [monitoring/kube-prometheus-stack.yaml](monitoring/kube-prometheus-stack.yaml), sans passer par AVP     |
 
 Côté Kubernetes (créés par ESO) :
 
 - `argocd/infra-secrets` — clé/valeur réutilisée par AVP via `<path:argocd:infra-secrets#email>` etc.
 - `argocd/private-gitops-deploy-secrets` — `kubernetes.io/ssh-auth`.
 - `argocd/argocd-private-gitops-ssh` — `Secret` typé `argocd.argoproj.io/secret-type: repository` consommé directement par Argo CD.
+- `argocd/argocd-staging-gitops-ssh` — idem pour `MonniHermes/staging-gitops`.
+
+### Ajouter la deploy key d'un nouveau repo privé
+
+Une deploy key GitHub est scopée à **un seul repo** : la clé d'un repo ne peut pas être réutilisée pour un autre, GitHub refuse l'enregistrement d'une clé publique déjà employée. Chaque repo privé branché sur Argo CD a donc sa propre paire et sa propre clé GCPSM.
+
+Si le repo appartient à une **organisation**, vérifier d'abord que les deploy keys y sont autorisées — le réglage est org-wide et vaut `false` par défaut sur les orgs récentes, l'ajout de clé échoue alors en `HTTP 422: Deploy keys are disabled for this repository` :
+
+```bash
+gh api orgs/<ORG> --jq .deploy_keys_enabled_for_repositories
+gh api -X PATCH orgs/<ORG> -f deploy_keys_enabled_for_repositories=true
+```
+
+```bash
+ssh-keygen -t ed25519 -C "argocd@amonnier.fr" -f ./deploy-key -N ""
+
+# Cle publique -> GitHub, en ecriture (--allow-write) si l'Image Updater
+# doit pousser des write-back sur ce repo.
+gh repo deploy-key add ./deploy-key.pub \
+  --repo MonniHermes/staging-gitops --title "ArgoCD Write" --allow-write
+
+# Cle privee -> GCP Secret Manager, sous le nom reference par l'ExternalSecret.
+gcloud secrets create k8s1-github-staging-gitops-deploy \
+  --project amonnier --data-file=./deploy-key
+
+shred -u ./deploy-key ./deploy-key.pub
+```
+
+Puis ajouter l'`ExternalSecret` correspondant dans [argo-secrets/](argo-secrets/) et l'`Application` racine dans [external-repos/](external-repos/).
 
 ## Comment AVP rend les secrets
 

--- a/argo-secrets/staging-gitops-deploy-secrets.yaml
+++ b/argo-secrets/staging-gitops-deploy-secrets.yaml
@@ -1,0 +1,28 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: argocd-staging-gitops-ssh
+  namespace: argocd
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: external-secrets
+  target:
+    name: argocd-staging-gitops-ssh
+    creationPolicy: Owner
+    template:
+      metadata:
+        labels:
+          argocd.argoproj.io/secret-type: repository
+      type: Opaque
+      data:
+        type: git
+        url: git@github.com:MonniHermes/staging-gitops.git
+        # Deploy key en ECRITURE : l'Image Updater fait son write-back git sur
+        # ce meme repo et reutilise ces credentials de repository.
+        sshPrivateKey: "{{ .mysecret | toString }}"
+  data:
+    - secretKey: mysecret
+      remoteRef:
+        key: k8s1-github-staging-gitops-deploy

--- a/external-repos/staging-gitops.yaml
+++ b/external-repos/staging-gitops.yaml
@@ -1,0 +1,23 @@
+# Copie de bootstrap/root-application.yaml du repo MonniHermes/staging-gitops :
+# on la porte ici pour que la racine soit elle aussi pilotee par GitOps plutot
+# que par un kubectl apply manuel. Garder les deux fichiers alignes.
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: staging-gitops-root
+  namespace: argocd
+spec:
+  project: infra
+  source:
+    repoURL: git@github.com:MonniHermes/staging-gitops.git
+    path: argocd
+    targetRevision: main
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: argocd
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true


### PR DESCRIPTION
Les environnements de staging (chroma-unveil, naoki-card) ont été sortis de `private-gitops` vers [MonniHermes/staging-gitops](https://github.com/MonniHermes/staging-gitops), qui porte lui-même ses Applications et ses ImageUpdaters sous `argocd/`. Deux pièces manquaient côté cluster.

## `argo-secrets/staging-gitops-deploy-secrets.yaml`

`ExternalSecret` qui matérialise la deploy key SSH en Secret labellisé `argocd.argoproj.io/secret-type: repository`, sans quoi Argo CD ne peut pas lire un repo privé d'une autre orga. La clé est en **écriture** : l'Image Updater réutilise ces credentials de repository pour son write-back Kustomize.

Une deploy key GitHub étant scopée à un seul repo, celle de `private-gitops` n'était pas réutilisable — nouvelle clé GCPSM `k8s1-github-staging-gitops-deploy`.

## `external-repos/staging-gitops.yaml`

L'Application racine `staging-gitops-root`, copie de `bootstrap/root-application.yaml` du repo staging, pour que la racine soit pilotée par GitOps plutôt que par un `kubectl apply` manuel. Garder les deux fichiers alignés.

## Prérequis déjà satisfaits

- [x] `deploy_keys_enabled_for_repositories` réactivé sur l'org `MonniHermes` (valait `false`, ce qui faisait échouer l'ajout de clé en `HTTP 422`).
- [x] Deploy key ed25519 « ArgoCD Write » posée sur le repo, en écriture.
- [x] Clé privée dans GCPSM sous `k8s1-github-staging-gitops-deploy` (projet `amonnier`), empreinte vérifiée identique à celle enregistrée sur GitHub.

## Ordre de merge

À merger **après** [monnierant/private-gitops#20](https://github.com/monnierant/private-gitops/pull/20), qui retire les Applications staging historiques. Deux Applications en `selfHeal` sur les mêmes ressources se disputeraient l'ownership.

Cette voie est plus grossière que `docs/cutover-runbook.md` du repo staging : les deux applications basculent d'un coup, sans point de contrôle intermédiaire. Le résultat net est le même.

🤖 Generated with [Claude Code](https://claude.com/claude-code)